### PR TITLE
Add scripts to upgrade to the latest version of node

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,18 @@ $ wget -O - https://raw.githubusercontent.com/sdesalas/node-pi-zero/master/insta
 $ wget -O - https://raw.githubusercontent.com/sdesalas/node-pi-zero/master/install-node-v.last.sh | bash
 ```
 
+## Upgrade to latest version of node (with option to install if node is not already installed)
+
+```sh
+$ wget -qO - https://raw.githubusercontent.com/sdesalas/node-pi-zero/master/upgrade-node-latest.sh | bash
+```
+
+## Upgrade to latest LTS version of node (with option to install if node is not already installed)
+
+```sh
+$ wget -qO - https://raw.githubusercontent.com/sdesalas/node-pi-zero/master/upgrade-node-lts.sh | bash
+```
+
 Looking for a specific version? The [following fork](https://github.com/Grayda/node-pi-zero) which has every version listed.
 
 When finished just check the node and npm versions.
@@ -140,6 +152,11 @@ $ npm -v
 Add the following to the end of your `~/.profile` file:
 ```sh
 # Add support for node CLI tools
+export PATH=$PATH:/opt/nodejs/bin
+```
+
+As a second option (to enable node to be accessible to all users including root), create a file in `/etc/profile.d` called `nodepath.sh` with these contents:
+```sh
 export PATH=$PATH:/opt/nodejs/bin
 ```
 

--- a/upgrade-node-latest.sh
+++ b/upgrade-node-latest.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# By Dave Johnson (@thisDaveJ)
+
+# Leveraging prior work of:
+#  Steven de Sales https://github.com/sdesalas/node-pi-zero/
+#  Kees C. Bakker https://raw.githubusercontent.com/sdesalas/node-pi-zero/master/install-node-v.last.sh
+
+install_node () {
+  echo "Installing node $1";
+  wget -O - https://raw.githubusercontent.com/sdesalas/node-pi-zero/master/install-node-v.last.sh | bash
+}
+
+#get pi ARM version
+PI_ARM_VERSION=$(uname -a | egrep 'armv[0-9]+l' -o);
+
+#get latest nodejs version from node website
+#read the first version that matches the arm platform
+LATEST_NODE_VERSION=$(curl -s https://nodejs.org/dist/index.json | 
+egrep "{\"version\":\"v([0-9]+\.?){3}\"[^{]*\"linux-"$PI_ARM_VERSION"" -o | 
+head -n 1 | 
+egrep 'v([0-9]+\.?){3}' -o 
+);
+
+if ! [ -x "$(command -v node)" ]; then
+  while true; do
+    read -p "node is not installed. Install it now (y/n)? " yn
+    case $yn in
+      [Yy]* ) install_node $LATEST_NODE_VERSION
+              exit;;
+      [Nn]* ) exit;;
+      * ) echo "Please answer with y or n."
+              ;;
+    esac
+  done
+fi
+
+CURRENT_NODE_VERSION=$(node -v);
+
+if [ "$CURRENT_NODE_VERSION" != "$LATEST_NODE_VERSION" ]; then
+  echo "node current version: $CURRENT_NODE_VERSION";
+  echo "node latest version: $LATEST_NODE_VERSION";
+  while true; do
+    read -p "Do you wish to install the latest version (y/n)? " yn
+    case $yn in
+      [Yy]* ) install_node $LATEST_NODE_VERSION
+              exit;;
+      [Nn]* ) exit;;
+      * ) echo "Please answer with y or n."
+              ;;
+    esac
+  done
+else
+  echo "You have node $CURRENT_NODE_VERSION installed which is the latest version."
+fi

--- a/upgrade-node-latest.sh
+++ b/upgrade-node-latest.sh
@@ -50,5 +50,5 @@ if [ "$CURRENT_NODE_VERSION" != "$LATEST_NODE_VERSION" ]; then
     esac
   done
 else
-  echo "You have node $CURRENT_NODE_VERSION installed which is the latest version."
+  echo "node $CURRENT_NODE_VERSION installed (latest version available)"
 fi

--- a/upgrade-node-lts.sh
+++ b/upgrade-node-lts.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# By Dave Johnson (@thisDaveJ)
+
+# Leveraging prior work of:
+#  Steven de Sales https://github.com/sdesalas/node-pi-zero/
+#  Kees C. Bakker https://raw.githubusercontent.com/sdesalas/node-pi-zero/master/install-node-v.last.sh
+
+install_node () {
+  echo "Installing node $1";
+  wget -O - https://raw.githubusercontent.com/sdesalas/node-pi-zero/master/install-node-v.lts.sh | bash
+}
+
+#get pi ARM version
+PI_ARM_VERSION=$(uname -a | egrep 'armv[0-9]+l' -o);
+
+#read the first version that matches the arm platform
+NODE_VERSION=$(
+  curl -s https://nodejs.org/dist/index.json | 
+  egrep "{\"version\":\"v([0-9]+\.?){3}\"[^{]*\"linux-"$PI_ARM_VERSION"[^}]*lts\":\"[^\"]+\"" -o |
+  head -n 1
+);
+
+#get the version
+LATEST_LTS_VERSION=$(
+  echo $NODE_VERSION | 
+  egrep 'v([0-9]+\.?){3}' -o
+);
+
+if ! [ -x "$(command -v node)" ]; then
+  while true; do
+    read -p "node is not installed. Install latest LTS version now (y/n)? " yn
+    case $yn in
+      [Yy]* ) install_node $LATEST_LTS_VERSION
+              exit;;
+      [Nn]* ) exit;;
+      * ) echo "Please answer with y or n."
+              ;;
+    esac
+  done
+fi
+
+CURRENT_NODE_VERSION=$(node -v);
+
+if [ "$CURRENT_NODE_VERSION" != "$LATEST_LTS_VERSION" ]; then
+  echo "node current version: $CURRENT_NODE_VERSION";
+  echo "node latest LTS version: $LATEST_LTS_VERSION";
+  while true; do
+    read -p "Do you wish to install the latest LTS version (y/n)? " yn
+    case $yn in
+      [Yy]* ) install_node $LATEST_LTS_VERSION
+              exit;;
+      [Nn]* ) exit;;
+      * ) echo "Please answer with y or n."
+              ;;
+    esac
+  done
+else
+  echo "You have node $CURRENT_NODE_VERSION installed which is the latest LTS version."
+fi

--- a/upgrade-node-lts.sh
+++ b/upgrade-node-lts.sh
@@ -55,5 +55,5 @@ if [ "$CURRENT_NODE_VERSION" != "$LATEST_LTS_VERSION" ]; then
     esac
   done
 else
-  echo "You have node $CURRENT_NODE_VERSION installed which is the latest LTS version."
+  echo "node $CURRENT_NODE_VERSION installed (latest LTS version available)"
 fi


### PR DESCRIPTION
This adds a couple upgrade scripts to make it easy for people to upgrade to the latest version of node (or the latest LTS version of node), leveraging the excellent scripts you already have in the repo.

I also added some verbiage in the README to provide a second way of adding node to the path so node can be invoked by the root user if needed too.

I'm planning to write a guide for installing Node.js on the Pi Zero with your scripts as the recommended option. The upgrade scripts would round out the offering and make it easy for people to check if node upgrades are available.  I envision people might download the upgrade scripts and run them locally to invoke your remote scripts.

Thanks for maintaining this repo. I have node running on my Pi Zero thanks to your work!